### PR TITLE
chore: Add step to debug trigger inputs

### DIFF
--- a/.github/workflows/Master-Scanning.yaml
+++ b/.github/workflows/Master-Scanning.yaml
@@ -146,6 +146,11 @@ jobs:
           else
             echo "No changes to commit for ${{ matrix.domain }}."
           fi
+
+      - name: Debug Inputs
+        run: |
+          echo "Debug: run_x8 value is ${{ github.event.inputs.run_x8 }}"
+          echo "Debug: run_kxss value is ${{ github.event.inputs.run_kxss }}"
       - name: Trigger Scanner for ${{ matrix.domain }}
         if: success() && (github.event.inputs.run_x8 == true || github.event.inputs.run_kxss == true)
         env:


### PR DESCRIPTION
This commit adds a temporary debugging step to the `process-domain` job. The new "Debug Inputs" step will print the raw values of the `github.event.inputs.run_x8` and `github.event.inputs.run_kxss` variables as seen by the workflow runner.

This is intended to diagnose an issue where the scanner trigger step, which is conditional on these inputs, is being skipped unexpectedly. The output of this step will allow us to verify the values and confirm whether the `if` condition is evaluating correctly.