### PR TITLE
I've implemented a fix to correctly pass output between jobs.

### DIFF
--- a/.github/workflows/Master-Scanning.yaml
+++ b/.github/workflows/Master-Scanning.yaml
@@ -230,6 +230,8 @@ jobs:
     needs: probe-and-filter-legacy
     if: ${{ github.event.inputs.input_mode == 'url_list' }}
     runs-on: ubuntu-latest
+    outputs:
+      TARGET_NAME: ${{ steps.tgt.outputs.TARGET_NAME }}
     steps:
       - name: Compute target name
         id: tgt
@@ -284,7 +286,7 @@ jobs:
             -d '{
               "event_type": "xss-scan",
               "client_payload": {
-                "target_name": "'"${{ steps.tgt.outputs.TARGET_NAME }}"'",
+                "target_name": "'"${{ needs.commit-results-legacy.outputs.TARGET_NAME }}"'",
                 "storage_repo": "'"${{ github.event.inputs.storage_repo }}"'",
                 "custom_cookie": "'"${{ github.event.inputs.custom_cookie }}"'",
                 "custom_header": "'"${{ github.event.inputs.custom_header }}"'",
@@ -302,7 +304,7 @@ jobs:
             -d '{
               "event_type": "dalfox-scan",
               "client_payload": {
-                "target_name": "'"${{ steps.tgt.outputs.TARGET_NAME }}"'",
+                "target_name": "'"${{ needs.commit-results-legacy.outputs.TARGET_NAME }}"'",
                 "storage_repo": "'"${{ github.event.inputs.storage_repo }}"'",
                 "custom_cookie": "'"${{ github.event.inputs.custom_cookie }}"'",
                 "custom_header": "'"${{ github.event.inputs.custom_header }}"'"
@@ -318,7 +320,7 @@ jobs:
             -d '{
               "event_type": "nuclei-scan",
               "client_payload": {
-                "target_name": "'"${{ steps.tgt.outputs.TARGET_NAME }}"'",
+                "target_name": "'"${{ needs.commit-results-legacy.outputs.TARGET_NAME }}"'",
                 "storage_repo": "'"${{ github.event.inputs.storage_repo }}"'",
                 "custom_cookie": "'"${{ github.event.inputs.custom_cookie }}"'",
                 "custom_header": "'"${{ github.event.inputs.custom_header }}"'"


### PR DESCRIPTION
I found that the `trigger-scanners-legacy` job was attempting to use a step output from the `commit-results-legacy` job directly, which isn't possible in GitHub Actions.

I have corrected the workflow by:
1.  Adding an `outputs` section to the `commit-results-legacy` job to formally expose the `TARGET_NAME`.
2.  Updating the `trigger-scanners-legacy` job to consume this output using the `needs` context.

This will ensure that the `target_name` is passed correctly between the jobs.