### PR TITLE
Fix: Correct Dalfox workflow filename in API call

### DIFF
--- a/.github/workflows/Master-Scanning.yaml
+++ b/.github/workflows/Master-Scanning.yaml
@@ -155,7 +155,7 @@ jobs:
           curl -s -X POST \
             -H "Authorization: token $GH_PAT" \
             -H "Accept: application/vnd.github.v3+json" \
-            https://api.github.com/repos/ACCOUNT4/Dalfox-Scanner/actions/workflows/dalfox-workflow.yaml/dispatches \
+            https://api.github.com/repos/ACCOUNT4/Dalfox-Scanner/actions/workflows/dalfox-scanner.yml/dispatches \
             -d '{
               "ref": "main",
               "inputs": {


### PR DESCRIPTION
This commit fixes a filename mismatch in the `workflow_dispatch` API call that triggers the Dalfox scanner.

The URL was pointing to `dalfox-workflow.yaml`, but your actual file is named `dalfox-scanner.yml`. This change updates the API call to use the correct filename.

This is the final change from my side. To complete the solution, you must now copy the contents of the `dalfox-workflow-template.yaml` and `dalfox_payload.txt` files from this repository into your `mamadzht-max/Dalfox-Scanner` repository.