### PR TITLE
fix: Update deprecated artifact actions to v4

### DIFF
--- a/.github/workflows/dalfox-workflow-template.yaml
+++ b/.github/workflows/dalfox-workflow-template.yaml
@@ -55,7 +55,7 @@ jobs:
           echo "chunks=$chunks" >> $GITHUB_OUTPUT
 
       - name: Upload chunks as artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: url-chunks
           path: url_chunks/
@@ -73,7 +73,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Download URL chunks
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: url-chunks
           path: url_chunks/


### PR DESCRIPTION
This commit fixes a workflow error caused by deprecated GitHub Actions.

- Updates `actions/upload-artifact` from `v3` to `v4`.
- Updates `actions/download-artifact` from `v3` to `v4`.

This resolves the error "This request has been automatically failed because it uses a deprecated version of `actions/upload-artifact: v3`."