### PR TITLE
feat: Refactor Dalfox workflow for parallel execution and stability

### DIFF
--- a/.github/workflows/dalfox-workflow-template.yaml
+++ b/.github/workflows/dalfox-workflow-template.yaml
@@ -152,29 +152,46 @@ jobs:
           echo "Dalfox scan complete for chunk: ${{ matrix.chunk }}. Output saved to $OUTPUT_FILE"
           echo "::set-output name=output_file::$OUTPUT_FILE"
 
-      - name: Push results to storage repo
+      - name: Upload Dalfox results artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: dalfox-results-chunk-${{ matrix.chunk }}
+          path: ${{ steps.dalfox.outputs.output_file }}
+
+  push-to-storage:
+    needs: parallel-scan
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup SSH and Git
         env:
           DEPLOY_KEY: ${{ secrets.DEPLOY_KEY }}
-          STORAGE_REPO: ${{ github.event.inputs.storage_repo }}
         run: |
-          set -e
-          git clone "$STORAGE_REPO" storage_repo_clone
-          cd storage_repo_clone
+          mkdir -p ~/.ssh/
+          echo "${DEPLOY_KEY}" > ~/.ssh/id_rsa
+          chmod 600 ~/.ssh/id_rsa
+          ssh-keyscan github.com >> ~/.ssh/known_hosts
+          git config --global user.email "actions@github.com"
+          git config --global user.name "GitHub Actions"
+      - name: Download all scan results
+        uses: actions/download-artifact@v4
+        with:
+          path: all-dalfox-results
+      - name: Push results to storage repo
+        run: |
+          git clone ${{ github.event.inputs.storage_repo }} storage
+          cd storage
 
           TARGET_DIR="${{ github.event.inputs.target_name }}/xss"
           mkdir -p "$TARGET_DIR"
 
-          RESULT_FILE_NAME="dalfox-results-${{ matrix.chunk }}"
-          mv "../${{ steps.dalfox.outputs.output_file }}" "$TARGET_DIR/$RESULT_FILE_NAME"
+          # Consolidate all dalfox results into one file
+          find ../all-dalfox-results -type f -name "dalfox-output-*" -exec cat {} + > "$TARGET_DIR/dalfox.txt"
 
-          git config --global user.email "actions@github.com"
-          git config --global user.name "GitHub Actions"
           git add .
-
           if ! git diff --staged --quiet; then
-            git commit -m "Add Dalfox scan results for ${{ github.event.inputs.target_name }} (chunk ${{ matrix.chunk }})"
-            # Retry push on failure
-            for i in {1..3}; do git push && break || sleep 5; done
+            git commit -m "Add Dalfox scan results for ${{ github.event.inputs.target_name }}"
+            git push
           else
-            echo "No changes to commit for chunk ${{ matrix.chunk }}"
+            echo "No changes to commit"
           fi


### PR DESCRIPTION
I've just completed a major refactoring of the Dalfox scanner workflow for you. This update addresses multiple bugs and introduces significant performance and feature enhancements.

**Key Changes:**

- **Parallel Execution:** I've restructured the workflow to execute scans in parallel. My new approach involves preparing the URLs, processing them concurrently, and then collecting all the results to be stored safely in a single step. This new model resolves previous git race conditions and significantly improves performance.

- **Custom Parameter Injection:** I now read the `params.txt` file from the discovery results and inject these parameters into the target URLs before I begin scanning.

- **Bug Fixes & Stability:**
    - I corrected the `dalfox` command flag from `--custom-payload-file` to `--custom-payload`.
    - I added the `--only-custom-payload` flag to ensure only your provided payloads are used.
    - To mitigate `panic` errors, I'm now using the `--skip-headless` flag and have reduced the number of concurrent processes.
    - I've updated the deprecated `v3` artifact actions to `v4`.
    - I fixed a bug in the JSON generation used for parallel scanning.