### PR TITLE
fix: Correct job dependencies in Master-Scanning workflow

### DIFF
--- a/.github/workflows/Master-Scanning.yaml
+++ b/.github/workflows/Master-Scanning.yaml
@@ -162,7 +162,7 @@ jobs:
 
   collect-and-trigger:
     name: Collect and Trigger for ${{ matrix.domain }}
-    needs: parallel-httpx
+    needs: [parallel-httpx, setup-domain-matrix]
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION
This commit fixes a critical bug in the `Master-Scanning.yaml` workflow that caused the `collect-and-trigger` job to fail.

- Adds the `setup-domain-matrix` job to the `needs` context of the `collect-and-trigger` job.
- This ensures the domain matrix is correctly passed to the final job, resolving the `fromJson: empty input` error.