### PR TITLE
fix: Correct git diff condition to ensure results are pushed

### DIFF
--- a/.github/workflows/Master-Scanning.yaml
+++ b/.github/workflows/Master-Scanning.yaml
@@ -210,8 +210,8 @@ jobs:
           cd storage
           git config user.name "GitHub Actions"
           git config user.email "actions@github.com"
-          if ! git diff --quiet; then
-            git add .
+          git add .
+          if ! git diff --staged --quiet; then
             git commit -m "Discovery for $DOMAIN" || echo "No changes"
             git push
           else


### PR DESCRIPTION
This commit fixes a critical bug in the `Commit discovery results` step of the `Master-Scanning.yaml` workflow.

- The `if` condition was changed from `if ! git diff --quiet;` to `if ! git diff --staged --quiet;` and moved after the `git add .` command.
- This ensures that new files are correctly detected as changes to be committed, which prevents the `git push` operation from being skipped. This should resolve the issue where downstream workflows could not find the discovery files.