### PR TITLE
Fix: Correct Dalfox scanner flag

### DIFF
--- a/.github/workflows/dalfox-workflow-template.yaml
+++ b/.github/workflows/dalfox-workflow-template.yaml
@@ -73,7 +73,7 @@ jobs:
           # Run dalfox once on the entire file of URLs
           # It automatically finds and tests parameters in the URLs.
           $HOME/go/bin/dalfox file "$URL_FILE_PATH" \
-            --custom-payload-file "$PAYLOAD_FILE" \
+            --custom-payload "$PAYLOAD_FILE" \
             -b "$BLIND_XSS_URL" \
             --silence \
             -o "$OUTPUT_FILE" \


### PR DESCRIPTION
In the .github/workflows/dalfox-workflow-template.yaml file, the incorrect flag --custom-payload-file has been changed to the correct flag --custom-payload.

This resolves the final remaining issue in the multi-scanner pipeline, allowing the Dalfox scanner to run correctly.