### PR TITLE
Fix Dalfox panic and set concurrency

### DIFF
--- a/.github/workflows/dalfox-workflow-template.yaml
+++ b/.github/workflows/dalfox-workflow-template.yaml
@@ -77,6 +77,8 @@ jobs:
             -b "$BLIND_XSS_URL" \
             --silence \
             -o "$OUTPUT_FILE" \
+            --worker 20 \
+            --skip-headless \
             "${HEADER_ARGS[@]}"
 
           echo "Dalfox scan complete. Output saved to $OUTPUT_FILE"


### PR DESCRIPTION
- Adds the '--skip-headless' flag to the Dalfox command to prevent a panic caused by the underlying chromedp library. This disables DOM XSS scanning but allows the main scan to complete.
- Adds the '--worker 20' flag to set the number of concurrent workers to 20, as requested.