### PR TITLE
Fix: Update SQLi scanner trigger to external repository

### DIFF
--- a/.github/workflows/Master-Scanning.yaml
+++ b/.github/workflows/Master-Scanning.yaml
@@ -197,7 +197,7 @@ jobs:
           curl -s -X POST \
             -H "Authorization: token $GH_PAT" \
             -H "Accept: application/vnd.github.v3+json" \
-            "https://api.github.com/repos/${{ github.repository }}/actions/workflows/sqli-workflow-template.yaml/dispatches" \
+            "https://api.github.com/repos/amirbigiss/Sqli-Scanner/actions/workflows/sqli-workflow-template.yaml/dispatches" \
             -d '{
               "ref": "main",
               "inputs": {
@@ -364,7 +364,7 @@ jobs:
           curl -s -X POST \
             -H "Authorization: token $GH_PAT" \
             -H "Accept: application/vnd.github.v3+json" \
-            "https://api.github.com/repos/${{ github.repository }}/actions/workflows/sqli-workflow-template.yaml/dispatches" \
+            "https://api.github.com/repos/amirbigiss/Sqli-Scanner/actions/workflows/sqli-workflow-template.yaml/dispatches" \
             -d '{
               "ref": "main",
               "inputs": {


### PR DESCRIPTION
This commit updates the `Master-Scanning.yaml` workflow to trigger the SQLi scanner from the correct, external repository as requested by the user.

The trigger URL has been changed from the internal repository path to `amirbigiss/Sqli-Scanner`.