### PR TITLE
Fix: Improve scanner performance and fix Nuclei error

### DIFF
--- a/.github/workflows/dalfox-workflow-template.yaml
+++ b/.github/workflows/dalfox-workflow-template.yaml
@@ -111,6 +111,7 @@ jobs:
             -b "$BLIND_XSS_URL" \
             --silence \
             --skip-headless \
+            --fast-scan \
             -o "$OUTPUT_FILE" \
             "${HEADER_ARGS[@]}"
       - name: Upload Dalfox results artifact

--- a/.github/workflows/sqli-workflow-template.yaml
+++ b/.github/workflows/sqli-workflow-template.yaml
@@ -102,7 +102,7 @@ jobs:
 
           # Use nuclei with SQLi templates to find vulnerable URLs
           if [[ -s "$INPUT_FILE" ]]; then
-            nuclei -l "$INPUT_FILE" -t "vulnerabilities/sql-injection" -o "$NUCLEI_OUTPUT"
+            nuclei -l "$INPUT_FILE" -t sqli -o "$NUCLEI_OUTPUT"
           else
             touch "$NUCLEI_OUTPUT"
           fi
@@ -117,7 +117,7 @@ jobs:
           mkdir -p sqli-results-${{ matrix.chunk }}
           INPUT_FILE="final-sqli-candidates.txt"
           if [[ -s "$INPUT_FILE" ]]; then
-            sqlmap -m "$INPUT_FILE" --batch --random-agent --level=3 --risk=3 --output-dir="sqli-results-${{ matrix.chunk }}"
+            sqlmap -m "$INPUT_FILE" --batch --random-agent --level=3 --risk=3 --threads=10 --output-dir="sqli-results-${{ matrix.chunk }}"
           else
             echo "No potential SQLi candidates found to scan."
             touch "sqli-results-${{ matrix.chunk }}/sqlmap.log"


### PR DESCRIPTION
This commit addresses several issues in the Dalfox and SQLi scanner workflows.

- In `dalfox-workflow-template.yaml`, the `--fast-scan` flag has been added to the Dalfox command. This prevents the scanner from getting stuck on a single URL and ensures all targets in a chunk are scanned.

- In `sqli-workflow-template.yaml`:
  - The Nuclei command has been corrected to use the `-t sqli` tag instead of an invalid file path, which was causing the workflow to fail.
  - The `--threads=10` flag has been added to the `sqlmap` command to improve its performance and prevent it from getting stuck on a single target.