### PR TITLE
Fix: Final corrections for Dalfox and Nuclei scanners

### DIFF
--- a/.github/workflows/dalfox-workflow-template.yaml
+++ b/.github/workflows/dalfox-workflow-template.yaml
@@ -112,6 +112,7 @@ jobs:
             --silence \
             --skip-headless \
             --fast-scan \
+            --skip-mining-all \
             -o "$OUTPUT_FILE" \
             "${HEADER_ARGS[@]}"
       - name: Upload Dalfox results artifact

--- a/.github/workflows/sqli-workflow-template.yaml
+++ b/.github/workflows/sqli-workflow-template.yaml
@@ -102,7 +102,7 @@ jobs:
 
           # Use nuclei with SQLi templates to find vulnerable URLs
           if [[ -s "$INPUT_FILE" ]]; then
-            nuclei -l "$INPUT_FILE" -t sqli -o "$NUCLEI_OUTPUT"
+            nuclei -l "$INPUT_FILE" -tags sqli -o "$NUCLEI_OUTPUT"
           else
             touch "$NUCLEI_OUTPUT"
           fi


### PR DESCRIPTION
This commit applies the final set of fixes to the Dalfox and SQLi scanner workflows to resolve persistent errors and performance issues.

- In `dalfox-workflow-template.yaml`, the `--skip-mining-all` flag is added to the Dalfox command. This prevents the scanner from getting stuck in the parameter mining phase and ensures it processes all URLs in its chunk.

- In `sqli-workflow-template.yaml`, the Nuclei command is corrected to use the `-tags sqli` flag instead of `-t sqli`. The `-t` flag is for files/directories, while `-tags` correctly filters by metadata, resolving the 'template not found' error.