### PR TITLE
Fix: Rework Dalfox logic and apply definitive Nuclei fix

### DIFF
--- a/.github/workflows/dalfox-workflow-template.yaml
+++ b/.github/workflows/dalfox-workflow-template.yaml
@@ -131,15 +131,18 @@ jobs:
             HEADER_ARGS+=(-H "${{ github.event.inputs.custom_header }}")
           fi
 
-          $HOME/go/bin/dalfox file "$INPUT_FILE" \
-            --custom-payload "$PAYLOAD_FILE" \
-            -b "$BLIND_XSS_URL" \
-            --silence \
-            --skip-headless \
-            --fast-scan \
-            --skip-mining-all \
-            -o "$OUTPUT_FILE" \
-            "${HEADER_ARGS[@]}"
+          # Loop through each hydrated URL and run dalfox individually
+          while IFS= read -r url; do
+            echo "Scanning URL: $url"
+            $HOME/go/bin/dalfox url "$url" \
+              --custom-payload "$PAYLOAD_FILE" \
+              -b "$BLIND_XSS_URL" \
+              --silence \
+              --skip-headless \
+              --fast-scan \
+              --skip-mining-all \
+              "${HEADER_ARGS[@]}" >> "$OUTPUT_FILE"
+          done < "$INPUT_FILE"
       - name: Upload Dalfox results artifact
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/sqli-workflow-template.yaml
+++ b/.github/workflows/sqli-workflow-template.yaml
@@ -102,7 +102,7 @@ jobs:
 
           # Use nuclei with SQLi templates to find vulnerable URLs
           if [[ -s "$INPUT_FILE" ]]; then
-            nuclei -l "$INPUT_FILE" -t http/vulnerabilities/sqli/ -o "$NUCLEI_OUTPUT"
+            nuclei -l "$INPUT_FILE" -t 'http/vulnerabilities/sqli/*.yaml' -o "$NUCLEI_OUTPUT"
           else
             touch "$NUCLEI_OUTPUT"
           fi


### PR DESCRIPTION
This commit implements the definitive solutions for the Dalfox and SQLi scanner workflows, addressing persistent performance and runtime errors.

- The Dalfox workflow (`dalfox-workflow-template.yaml`) has been fundamentally reworked. Instead of a single `dalfox file` command, the scan step now uses a `while` loop to iterate through the hydrated URL list and execute `dalfox url` on each URL individually. This is a more robust approach that prevents the scanner from getting stuck.

- The SQLi workflow (`sqli-workflow-template.yaml`) is fixed by correcting the Nuclei command. It now uses the explicit file glob pattern `-t 'http/vulnerabilities/sqli/*.yaml'` to load all standard SQLi templates, which resolves the "template not found" error.