### PR TITLE
Fix: Add Dalfox timeout and definitive Nuclei tag fix

### DIFF
--- a/.github/workflows/dalfox-workflow-template.yaml
+++ b/.github/workflows/dalfox-workflow-template.yaml
@@ -134,7 +134,7 @@ jobs:
           # Loop through each hydrated URL and run dalfox individually
           while IFS= read -r url; do
             echo "Scanning URL: $url"
-            $HOME/go/bin/dalfox url "$url" \
+            timeout 300 $HOME/go/bin/dalfox url "$url" \
               --custom-payload "$PAYLOAD_FILE" \
               -b "$BLIND_XSS_URL" \
               --silence \

--- a/.github/workflows/sqli-workflow-template.yaml
+++ b/.github/workflows/sqli-workflow-template.yaml
@@ -102,7 +102,7 @@ jobs:
 
           # Use nuclei with SQLi templates to find vulnerable URLs
           if [[ -s "$INPUT_FILE" ]]; then
-            nuclei -l "$INPUT_FILE" -t 'http/vulnerabilities/sqli/*.yaml' -o "$NUCLEI_OUTPUT"
+            nuclei -l "$INPUT_FILE" -tags sqli -o "$NUCLEI_OUTPUT"
           else
             touch "$NUCLEI_OUTPUT"
           fi


### PR DESCRIPTION
This commit implements the definitive solutions for the Dalfox and SQLi scanner workflows, addressing persistent performance and runtime errors.

- In the Dalfox workflow, the `dalfox url` command is now wrapped in a `timeout 300` call. This prevents the scanner from hanging on a single complex URL and ensures the entire list is processed.

- In the SQLi workflow, the Nuclei command has been corrected to use the `-tags sqli` flag. This is the correct flag for filtering templates by metadata tags and resolves the "template not found" error.