### PR TITLE
Fix: Final logic for Dalfox and SQLi scanners

### DIFF
--- a/.github/workflows/dalfox-workflow-template.yaml
+++ b/.github/workflows/dalfox-workflow-template.yaml
@@ -137,7 +137,6 @@ jobs:
             timeout 300 $HOME/go/bin/dalfox url "$url" \
               --custom-payload "$PAYLOAD_FILE" \
               -b "$BLIND_XSS_URL" \
-              --silence \
               --skip-headless \
               --fast-scan \
               --skip-mining-all \

--- a/.github/workflows/sqli-workflow-template.yaml
+++ b/.github/workflows/sqli-workflow-template.yaml
@@ -102,7 +102,7 @@ jobs:
 
           # Use nuclei with SQLi templates to find vulnerable URLs
           if [[ -s "$INPUT_FILE" ]]; then
-            nuclei -l "$INPUT_FILE" -tags sqli -o "$NUCLEI_OUTPUT"
+            nuclei -l "$INPUT_FILE" -t http/vulnerabilities/generic/error-based-sql-injection.yaml -o "$NUCLEI_OUTPUT"
           else
             touch "$NUCLEI_OUTPUT"
           fi


### PR DESCRIPTION
This commit implements the final, definitive fixes for the Dalfox and SQLi scanner workflows based on detailed testing and feedback.

- In the Dalfox workflow (`dalfox-workflow-template.yaml`), the `--silence` flag has been removed from the `dalfox url` command. This will provide more verbose logging to confirm that all URLs are being scanned, addressing user concerns about the output.

- In the SQLi workflow (`sqli-workflow-template.yaml`), the Nuclei command has been changed to use a single, high-signal template for error-based SQLi (`-t http/vulnerabilities/generic/error-based-sql-injection.yaml`). This prevents the workflow from crashing due to an excessive number of templates and focuses the pre-scan filtering on the most likely candidates for `sqlmap`.