### PR TITLE
Fix: Prevent Dalfox workflow from failing on no vulnerabilities

### DIFF
--- a/.github/workflows/dalfox-workflow-template.yaml
+++ b/.github/workflows/dalfox-workflow-template.yaml
@@ -151,8 +151,11 @@ jobs:
               "${HEADER_ARGS[@]}"
           done < "$INPUT_FILE"
 
-          # Consolidate all temporary results into the final output file
-          cat "$TEMP_DIR"/*.txt > "$FINAL_OUTPUT_FILE"
+          # Consolidate all temporary results into the final output file, if any
+          touch "$FINAL_OUTPUT_FILE"
+          if ls "$TEMP_DIR"/*.txt >/dev/null 2>&1; then
+            cat "$TEMP_DIR"/*.txt > "$FINAL_OUTPUT_FILE"
+          fi
       - name: Upload Dalfox results artifact
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
The Dalfox workflow was failing when a scan chunk found no vulnerabilities. This was because the `cat` command would fail if no report files were created, and `set -e` would cause the script to exit.

This change makes the results consolidation step more robust by first creating an empty output file, and then checking if any temporary result files exist before attempting to concatenate them. This ensures the workflow completes successfully even if no vulnerabilities are found in a chunk.