### PR TITLE
Feat: Improve Dalfox report logging

### DIFF
--- a/.github/workflows/dalfox-workflow-template.yaml
+++ b/.github/workflows/dalfox-workflow-template.yaml
@@ -140,7 +140,8 @@ jobs:
             COUNTER=$((COUNTER+1))
             TEMP_FILE="$TEMP_DIR/result-$COUNTER.txt"
             echo "Scanning URL: $url"
-            # Use -o to save a clean report for each URL to a temporary file
+            # Use -o to save a clean report, and redirect stdout/stderr to a log file
+            # Add '|| true' to prevent the workflow from stopping if one URL fails
             timeout 300 $HOME/go/bin/dalfox url "$url" \
               --custom-payload "$PAYLOAD_FILE" \
               -b "$BLIND_XSS_URL" \
@@ -148,13 +149,16 @@ jobs:
               --fast-scan \
               --skip-mining-all \
               -o "$TEMP_FILE" \
-              "${HEADER_ARGS[@]}"
+              "${HEADER_ARGS[@]}" > "$TEMP_FILE.log" 2>&1 || true
           done < "$INPUT_FILE"
 
-          # Consolidate all temporary results into the final output file, if any
-          touch "$FINAL_OUTPUT_FILE"
-          if ls "$TEMP_DIR"/*.txt >/dev/null 2>&1; then
+          # Consolidate results. If POCs are found, use them. Otherwise, use logs.
+          if find "$TEMP_DIR" -name "*.txt" -size +0c -print -quit | grep -q .; then
+            echo "Vulnerabilities found. Consolidating POCs."
             cat "$TEMP_DIR"/*.txt > "$FINAL_OUTPUT_FILE"
+          else
+            echo "No vulnerabilities found. Consolidating logs for review."
+            cat "$TEMP_DIR"/*.txt.log > "$FINAL_OUTPUT_FILE"
           fi
       - name: Upload Dalfox results artifact
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
This commit enhances the Dalfox scanning workflow to make its output more informative and less confusing.

When no vulnerabilities were found during a scan, the corresponding output file was empty, despite the console log showing that parameters were being reflected and tested. This behavior was correct but lacked context.

This change introduces conditional logging. The workflow now captures the full log for every URL scanned. If the scan chunk yields at least one vulnerability with a POC, the final report contains only the clean POCs. If no vulnerabilities are found, the report is populated with the full, concatenated logs from all the scans in that chunk.

This makes the process more transparent by ensuring the final report always contains relevant information about the scan's outcome.