### PR TITLE
Refactor: Parallelize httpx scan using a matrix strategy

### DIFF
--- a/.github/workflows/Master-Scanning.yaml
+++ b/.github/workflows/Master-Scanning.yaml
@@ -87,27 +87,24 @@ jobs:
           # Filter out common static file extensions to create a list for scanning
           grep -ivE "\\.(css|js|jpeg|jpg|png|gif|svg|ico|webp|pdf|mp4|mp3|eot|woff|woff2|ttf)(\\?.*)?$" work/urls.txt > work/filtered/non-static-urls.txt
 
-      - name: Find Live URLs
-        run: |
-          set -e
-          INPUT_FILE="work/filtered/non-static-urls.txt"
-          OUTPUT_FILE="work/filtered/live-urls.txt"
-          CHUNK_DIR="work/filtered/chunks"
+      - name: Upload URL list for httpx
+        uses: actions/upload-artifact@v4
+        with:
+          name: non-static-urls-${{ matrix.domain }}-${{ github.run_id }}
+          path: work/filtered/non-static-urls.txt
 
-          if [ ! -s "$INPUT_FILE" ]; then
-            echo "URL file is empty, skipping httpx scan."
-            touch "$OUTPUT_FILE"
-            exit 0
-          fi
+      - name: Run parallel httpx scan
+        id: httpx_scan
+        uses: ./.github/workflows/httpx-workflow.yaml
+        with:
+          url_artifact_name: non-static-urls-${{ matrix.domain }}-${{ github.run_id }}
+          run_id: ${{ github.run_id }}-${{ matrix.domain }}
 
-          mkdir -p "$CHUNK_DIR"
-          echo "Splitting URLs for parallel httpx scan..."
-          split -l 500 "$INPUT_FILE" "$CHUNK_DIR/chunk_"
-
-          echo "Running httpx in parallel on $(ls -1q "$CHUNK_DIR" | wc -l) chunks..."
-          find "$CHUNK_DIR" -type f -name "chunk_*" | xargs -P 20 -I {} httpx -l {} -silent -threads 25 -timeout 10 -retries 2 -follow-redirects >> "$OUTPUT_FILE"
-
-          echo "Parallel httpx scan complete. Found $(wc -l < "$OUTPUT_FILE") live URLs."
+      - name: Download live URL results
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ steps.httpx_scan.outputs.result_artifact_name }}
+          path: work/filtered
 
       - name: Commit discovery results
         env:

--- a/.github/workflows/httpx-workflow.yaml
+++ b/.github/workflows/httpx-workflow.yaml
@@ -1,0 +1,98 @@
+name: "Callable HTTPX Scan"
+
+on:
+  workflow_call:
+    inputs:
+      url_artifact_name:
+        description: 'The name of the artifact containing non-static-urls.txt'
+        required: true
+        type: string
+      run_id:
+        description: 'A unique ID for this run to create unique artifact names'
+        required: true
+        type: string
+    outputs:
+      result_artifact_name:
+        description: 'The name of the artifact containing the final live-urls.txt'
+        value: ${{ jobs.consolidate-results.outputs.artifact_name }}
+
+jobs:
+  scan-in-parallel:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        # Running on 20 parallel jobs
+        chunk: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20]
+    steps:
+      - name: Install httpx
+        run: |
+          go install -v github.com/projectdiscovery/httpx/cmd/httpx@latest
+          echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
+
+      - name: Download URL list artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ github.event.inputs.url_artifact_name }}
+          path: .
+
+      - name: Generate URL chunk file
+        id: generate_chunk
+        run: |
+          INPUT_FILE="non-static-urls.txt"
+          CHUNK_FILE="httpx-chunk-${{ matrix.chunk }}.txt"
+
+          if [ ! -s "$INPUT_FILE" ]; then
+            echo "URL file is empty, creating empty chunk file."
+            touch "$CHUNK_FILE"
+            echo "is_empty=true" >> $GITHUB_OUTPUT
+          else
+            TOTAL_LINES=$(wc -l < "$INPUT_FILE")
+            # Using 20 as the total number of chunks
+            LINES_PER_CHUNK=$(( (TOTAL_LINES + 20 - 1) / 20 ))
+            START_LINE=$((((${{ matrix.chunk }} - 1) * LINES_PER_CHUNK) + 1))
+            END_LINE=$((${{ matrix.chunk }} * LINES_PER_CHUNK))
+            sed -n "${START_LINE},${END_LINE}p" "$INPUT_FILE" > "$CHUNK_FILE"
+            echo "is_empty=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Run httpx on chunk
+        if: steps.generate_chunk.outputs.is_empty == 'false'
+        run: |
+          httpx -l httpx-chunk-${{ matrix.chunk }}.txt -silent -threads 25 -timeout 10 -retries 2 -follow-redirects > live-urls-chunk-${{ matrix.chunk }}.txt
+
+      - name: Create empty result file if chunk was empty
+        if: steps.generate_chunk.outputs.is_empty == 'true'
+        run: touch live-urls-chunk-${{ matrix.chunk }}.txt
+
+      - name: Upload chunk result artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: live-urls-chunk-${{ matrix.chunk }}-${{ github.event.inputs.run_id }}
+          path: live-urls-chunk-${{ matrix.chunk }}.txt
+
+  consolidate-results:
+    runs-on: ubuntu-latest
+    needs: scan-in-parallel
+    outputs:
+      artifact_name: ${{ steps.set_artifact_name.outputs.name }}
+    steps:
+      - name: Set final artifact name
+        id: set_artifact_name
+        run: echo "name=live-urls-${{ github.event.inputs.run_id }}" >> $GITHUB_OUTPUT
+
+      - name: Download all chunk artifacts
+        uses: actions/download-artifact@v4
+        with:
+          # No name downloads all artifacts from the run
+          path: all-chunk-results
+
+      - name: Consolidate results
+        run: |
+          mkdir -p final-results
+          find all-chunk-results -type f -name "live-urls-chunk-*.txt" -exec cat {} + > final-results/live-urls.txt
+
+      - name: Upload final consolidated artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ steps.set_artifact_name.outputs.name }}
+          path: final-results/live-urls.txt


### PR DESCRIPTION
This commit refactors the `httpx` discovery scan from a single-job, multi-process model (`xargs`) to a multi-job, matrix strategy model.

This change was prompted by user feedback regarding performance, potential rate-limiting from a single IP, and the risk of hitting the 6-hour job timeout on very large target lists.

A new callable workflow, `httpx-workflow.yaml`, has been created. This workflow accepts a list of URLs, splits it, and runs `httpx` on each chunk in a separate, parallel job. It then consolidates the results.

The main `Master-Scanning.yaml` has been updated to remove the old `xargs`-based implementation and now calls this new workflow, waiting for its completion before proceeding. This new architecture is more scalable, faster, and more robust.