### PR TITLE
Fix: Add checkout step to allow local workflow call

### DIFF
--- a/.github/workflows/Master-Scanning.yaml
+++ b/.github/workflows/Master-Scanning.yaml
@@ -62,6 +62,9 @@ jobs:
       COOKIE: ${{ github.event.inputs.custom_cookie }}
       HEADER: ${{ github.event.inputs.custom_header }}
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
       - name: Install tools
         run: |
           sudo apt-get update


### PR DESCRIPTION
The `process-domain` job was failing to call the local reusable workflow (`.github/workflows/httpx-workflow.yaml`) because it was missing a checkout step.

This commit adds the `actions/checkout@v3` step to the beginning of the `process-domain` job. This makes the repository's files available to the runner, allowing the `uses: ./.github/workflows/httpx-workflow.yaml` directive to find and execute the callable workflow correctly.