### PR TITLE
Fix: Add permissions to allow checkout for local workflow call

### DIFF
--- a/.github/workflows/Master-Scanning.yaml
+++ b/.github/workflows/Master-Scanning.yaml
@@ -51,6 +51,8 @@ jobs:
 
   process-domain:
     name: Process each domain
+    permissions:
+      contents: read
     needs: setup-matrix
     if: ${{ github.event.inputs.input_mode != 'url_list' }}
     runs-on: ubuntu-latest


### PR DESCRIPTION
The `process-domain` job continued to fail to call the local reusable workflow even after adding a checkout step. The root cause appears to be missing permissions for the job to read the repository's contents.

This commit adds `permissions: contents: read` to the `process-domain` job. This grant is necessary for the `actions/checkout@v3` step to function correctly, which in turn allows the runner to find and use the local callable workflow at `.github/workflows/httpx-workflow.yaml`.