### PR TITLE
Fix: Use explicit path for local callable workflow

### DIFF
--- a/.github/workflows/Master-Scanning.yaml
+++ b/.github/workflows/Master-Scanning.yaml
@@ -100,7 +100,7 @@ jobs:
 
       - name: Run parallel httpx scan
         id: httpx_scan
-        uses: ./.github/workflows/httpx-workflow.yaml
+        uses: ${{ github.repository_owner }}/${{ github.event.repository.name }}/.github/workflows/httpx-workflow.yaml@${{ github.ref }}
         with:
           url_artifact_name: non-static-urls-${{ matrix.domain }}-${{ github.run_id }}
           run_id: ${{ github.run_id }}-${{ matrix.domain }}


### PR DESCRIPTION
This is the third attempt to fix the "Can't find 'action.yml'" error when calling the local `httpx-workflow.yaml`.

The previous attempts (adding `checkout` and `permissions`) did not resolve the issue. This suggests the runner is ambiguously interpreting the shorthand `uses: ./path/to/workflow.yaml` as a local action instead of a callable workflow.

This commit changes the `uses` path to the full, explicit syntax: `uses: ${{ github.repository_owner }}/${{ github.event.repository.name }}/.github/workflows/httpx-workflow.yaml@${{ github.ref }}`

This syntax leaves no room for ambiguity and should correctly resolve to the callable workflow.