### PR TITLE
Fix: Correct syntax for dynamic matrix strategy

### DIFF
--- a/.github/workflows/Master-Scanning.yaml
+++ b/.github/workflows/Master-Scanning.yaml
@@ -115,7 +115,8 @@ jobs:
     needs: generate-httpx-matrix
     strategy:
       fail-fast: false
-      matrix: ${{ fromJson(needs.generate-httpx-matrix.outputs.matrix) }}
+      matrix:
+        include: ${{ fromJson(needs.generate-httpx-matrix.outputs.matrix) }}
     steps:
       - name: Install httpx
         run: |


### PR DESCRIPTION
The workflow was failing with a "A sequence was not expected" error when evaluating the strategy for the `run-httpx-scan` job.

This was caused by assigning the output of `fromJson()` directly to the `matrix` key. The correct syntax for including a dynamic list of job configurations is to place the expression under an `include` key within the `matrix` block.

This commit corrects the syntax, which should allow the dynamic matrix to be generated and evaluated correctly.