### PR TITLE
Fix: Resolve bad substitution error in httpx chunking script

### DIFF
--- a/.github/workflows/Master-Scanning.yaml
+++ b/.github/workflows/Master-Scanning.yaml
@@ -131,13 +131,14 @@ jobs:
 
       - name: Get URL chunk
         run: |
+          CHUNK_NUMBER=${{ matrix.chunk }}
           INPUT_FILE="non-static-urls.txt"
           CHUNK_FILE="httpx-chunk.txt"
           TOTAL_LINES=$(wc -l < "$INPUT_FILE")
           CHUNKS=20
           LINES_PER_CHUNK=$(( (TOTAL_LINES + CHUNKS - 1) / CHUNKS ))
-          START_LINE=$(( ((${matrix.chunk} - 1) * LINES_PER_CHUNK) + 1 ))
-          END_LINE=$(( ${matrix.chunk} * LINES_PER_CHUNK ))
+          START_LINE=$(( ((CHUNK_NUMBER - 1) * LINES_PER_CHUNK) + 1 ))
+          END_LINE=$(( CHUNK_NUMBER * LINES_PER_CHUNK ))
           sed -n "${START_LINE},${END_LINE}p" "$INPUT_FILE" > "$CHUNK_FILE"
 
       - name: Run httpx on chunk


### PR DESCRIPTION
The `run-httpx-scan` job was failing with a "bad substitution" error in the `Get URL chunk` step.

This was caused by using the GitHub Actions context variable `${{ matrix.chunk }}` directly inside a bash arithmetic expression `$(())`, which caused a syntax conflict.

This commit resolves the issue by first assigning the value of `${{ matrix.chunk }}` to a standard shell variable, and then using that variable in the subsequent arithmetic operations. This separates the GitHub Actions context from the shell execution and fixes the script.