### PR TITLE
feat(ci): Implement dynamic chunking for httpx scan

### DIFF
--- a/.github/workflows/Master-Scanning.yaml
+++ b/.github/workflows/Master-Scanning.yaml
@@ -97,7 +97,8 @@ jobs:
             url_file="$dir/non-static-urls.txt"
             if [ -s "$url_file" ]; then
               TOTAL_LINES=$(wc -l < "$url_file")
-              CHUNKS=200
+              LINES_PER_CHUNK=10000
+              CHUNKS=$(( (TOTAL_LINES + LINES_PER_CHUNK - 1) / LINES_PER_CHUNK ))
               for i in $(seq 1 $CHUNKS); do
                 if [ "$MATRIX" != "[" ]; then
                   MATRIX="$MATRIX,"
@@ -134,10 +135,8 @@ jobs:
           CHUNK_NUMBER=${{ matrix.chunk }}
           INPUT_FILE="non-static-urls.txt"
           CHUNK_FILE="httpx-chunk.txt"
-          TOTAL_LINES=$(wc -l < "$INPUT_FILE")
-          CHUNKS=200
-          LINES_PER_CHUNK=$(( (TOTAL_LINES + CHUNKS - 1) / CHUNKS ))
-          START_LINE=$(( ((CHUNK_NUMBER - 1) * LINES_PER_CHUNK) + 1 ))
+          LINES_PER_CHUNK=10000
+          START_LINE=$(( (CHUNK_NUMBER - 1) * LINES_PER_CHUNK + 1 ))
           END_LINE=$(( CHUNK_NUMBER * LINES_PER_CHUNK ))
           sed -n "${START_LINE},${END_LINE}p" "$INPUT_FILE" > "$CHUNK_FILE"
 


### PR DESCRIPTION
Replaces the fixed chunking logic with a dynamic approach.

The workflow now calculates the number of chunks based on the total number of URLs, with each chunk containing a maximum of 10,000 lines.

This prevents the creation of empty or near-empty jobs for small targets and avoids timeouts on very large targets by ensuring no single job processes an excessive number of URLs.