### PR TITLE
feat(ci): Implement dynamic chunking across all scanner workflows

### DIFF
--- a/.github/workflows/dalfox-workflow-template.yaml
+++ b/.github/workflows/dalfox-workflow-template.yaml
@@ -52,13 +52,43 @@ jobs:
           name: dalfox-combined-results-artifact
           path: combined-results/
 
-  dalfox-scan:
+  generate-matrix:
+    runs-on: ubuntu-latest
     needs: fetch-results
+    if: "needs.fetch-results.outputs.urls_exist == 'true'"
+    outputs:
+      matrix: ${{ steps.generate-matrix.outputs.matrix }}
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: dalfox-combined-results-artifact
+          path: combined-results/
+      - name: Generate Matrix
+        id: generate-matrix
+        run: |
+          MATRIX='['
+          url_file="combined-results/live-urls.txt"
+          if [ -s "$url_file" ]; then
+            TOTAL_LINES=$(wc -l < "$url_file")
+            LINES_PER_CHUNK=500
+            CHUNKS=$(( (TOTAL_LINES + LINES_PER_CHUNK - 1) / LINES_PER_CHUNK ))
+            for i in $(seq 1 $CHUNKS); do
+              if [ "$MATRIX" != "[" ]; then
+                MATRIX="$MATRIX,"
+              fi
+              MATRIX="$MATRIX{\"chunk\":$i}"
+            done
+          fi
+          MATRIX="$MATRIX]"
+          echo "matrix=$MATRIX" >> $GITHUB_OUTPUT
+
+  dalfox-scan:
+    needs: [fetch-results, generate-matrix]
     if: "needs.fetch-results.outputs.urls_exist == 'true'"
     runs-on: ubuntu-latest
     strategy:
-      matrix:
-        chunk: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20]
+      matrix: ${{ fromJson(needs.generate-matrix.outputs.matrix) }}
     steps:
       - name: Checkout main branch
         uses: actions/checkout@v3
@@ -76,8 +106,7 @@ jobs:
       - name: Generate URL chunk file
         run: |
           if [ -s combined-results/live-urls.txt ]; then
-            TOTAL_LINES=$(wc -l < combined-results/live-urls.txt)
-            LINES_PER_CHUNK=$(( (TOTAL_LINES + 20 - 1) / 20 ))
+            LINES_PER_CHUNK=500
             START_LINE=$((((${{ matrix.chunk }} - 1) * LINES_PER_CHUNK) + 1))
             END_LINE=$((${{ matrix.chunk }} * LINES_PER_CHUNK))
             sed -n "${START_LINE},${END_LINE}p" combined-results/live-urls.txt > dalfox-chunk-${{ matrix.chunk }}.txt

--- a/.github/workflows/nuclei-workflow-template.yaml
+++ b/.github/workflows/nuclei-workflow-template.yaml
@@ -51,13 +51,43 @@ jobs:
           name: nuclei-top10-combined-results-artifact
           path: combined-results/
 
-  nuclei-scan:
+  generate-matrix:
+    runs-on: ubuntu-latest
     needs: fetch-results
+    if: "needs.fetch-results.outputs.urls_exist == 'true'"
+    outputs:
+      matrix: ${{ steps.generate-matrix.outputs.matrix }}
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: nuclei-top10-combined-results-artifact
+          path: combined-results/
+      - name: Generate Matrix
+        id: generate-matrix
+        run: |
+          MATRIX='['
+          url_file="combined-results/live-urls.txt"
+          if [ -s "$url_file" ]; then
+            TOTAL_LINES=$(wc -l < "$url_file")
+            LINES_PER_CHUNK=10000
+            CHUNKS=$(( (TOTAL_LINES + LINES_PER_CHUNK - 1) / LINES_PER_CHUNK ))
+            for i in $(seq 1 $CHUNKS); do
+              if [ "$MATRIX" != "[" ]; then
+                MATRIX="$MATRIX,"
+              fi
+              MATRIX="$MATRIX{\"chunk\":$i}"
+            done
+          fi
+          MATRIX="$MATRIX]"
+          echo "matrix=$MATRIX" >> $GITHUB_OUTPUT
+
+  nuclei-scan:
+    needs: [fetch-results, generate-matrix]
     if: "needs.fetch-results.outputs.urls_exist == 'true'"
     runs-on: ubuntu-latest
     strategy:
-      matrix:
-        chunk: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20]
+      matrix: ${{ fromJson(needs.generate-matrix.outputs.matrix) }}
     steps:
       - name: Download artifacts
         uses: actions/download-artifact@v4
@@ -71,8 +101,7 @@ jobs:
       - name: Generate URL chunk file
         run: |
           if [ -s combined-results/live-urls.txt ]; then
-            TOTAL_LINES=$(wc -l < combined-results/live-urls.txt)
-            LINES_PER_CHUNK=$(( (TOTAL_LINES + 20 - 1) / 20 ))
+            LINES_PER_CHUNK=10000
             START_LINE=$((((${{ matrix.chunk }} - 1) * LINES_PER_CHUNK) + 1))
             END_LINE=$((${{ matrix.chunk }} * LINES_PER_CHUNK))
             sed -n "${START_LINE},${END_LINE}p" combined-results/live-urls.txt > nuclei-chunk-${{ matrix.chunk }}.txt

--- a/.github/workflows/sqli-workflow-template.yaml
+++ b/.github/workflows/sqli-workflow-template.yaml
@@ -51,13 +51,43 @@ jobs:
           name: combined-results-artifact
           path: combined-results/
 
-  sqli-scan:
+  generate-matrix:
+    runs-on: ubuntu-latest
     needs: fetch-results
+    if: "needs.fetch-results.outputs.urls_exist == 'true'"
+    outputs:
+      matrix: ${{ steps.generate-matrix.outputs.matrix }}
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: combined-results-artifact
+          path: combined-results/
+      - name: Generate Matrix
+        id: generate-matrix
+        run: |
+          MATRIX='['
+          url_file="combined-results/live-urls.txt"
+          if [ -s "$url_file" ]; then
+            TOTAL_LINES=$(wc -l < "$url_file")
+            LINES_PER_CHUNK=1000
+            CHUNKS=$(( (TOTAL_LINES + LINES_PER_CHUNK - 1) / LINES_PER_CHUNK ))
+            for i in $(seq 1 $CHUNKS); do
+              if [ "$MATRIX" != "[" ]; then
+                MATRIX="$MATRIX,"
+              fi
+              MATRIX="$MATRIX{\"chunk\":$i}"
+            done
+          fi
+          MATRIX="$MATRIX]"
+          echo "matrix=$MATRIX" >> $GITHUB_OUTPUT
+
+  sqli-scan:
+    needs: [fetch-results, generate-matrix]
     if: "needs.fetch-results.outputs.urls_exist == 'true'"
     runs-on: ubuntu-latest
     strategy:
-      matrix:
-        chunk: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20]
+      matrix: ${{ fromJson(needs.generate-matrix.outputs.matrix) }}
     steps:
       - name: Download artifacts
         uses: actions/download-artifact@v4
@@ -77,8 +107,7 @@ jobs:
       - name: Generate URL chunk file
         run: |
           if [ -s combined-results/live-urls.txt ]; then
-            TOTAL_LINES=$(wc -l < combined-results/live-urls.txt)
-            LINES_PER_CHUNK=$(( (TOTAL_LINES + 20 - 1) / 20 ))
+            LINES_PER_CHUNK=1000
             START_LINE=$((((${{ matrix.chunk }} - 1) * LINES_PER_CHUNK) + 1))
             END_LINE=$((${{ matrix.chunk }} * LINES_PER_CHUNK))
             sed -n "${START_LINE},${END_LINE}p" combined-results/live-urls.txt > sqli-chunk-${{ matrix.chunk }}.txt

--- a/.github/workflows/x8-kxss-workflow.yaml
+++ b/.github/workflows/x8-kxss-workflow.yaml
@@ -65,13 +65,43 @@ jobs:
           name: combined-results-artifact
           path: combined-results/
 
-  x8-scan:
+  generate-matrix:
+    runs-on: ubuntu-latest
     needs: fetch-results
+    if: "needs.fetch-results.outputs.urls_exist == 'true'"
+    outputs:
+      matrix: ${{ steps.generate-matrix.outputs.matrix }}
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: combined-results-artifact
+          path: combined-results/
+      - name: Generate Matrix
+        id: generate-matrix
+        run: |
+          MATRIX='['
+          url_file="combined-results/live-urls.txt"
+          if [ -s "$url_file" ]; then
+            TOTAL_LINES=$(wc -l < "$url_file")
+            LINES_PER_CHUNK=5000
+            CHUNKS=$(( (TOTAL_LINES + LINES_PER_CHUNK - 1) / LINES_PER_CHUNK ))
+            for i in $(seq 1 $CHUNKS); do
+              if [ "$MATRIX" != "[" ]; then
+                MATRIX="$MATRIX,"
+              fi
+              MATRIX="$MATRIX{\"chunk\":$i}"
+            done
+          fi
+          MATRIX="$MATRIX]"
+          echo "matrix=$MATRIX" >> $GITHUB_OUTPUT
+
+  x8-scan:
+    needs: [fetch-results, generate-matrix]
     if: "github.event.inputs.run_x8 == 'true' && needs.fetch-results.outputs.urls_exist == 'true' && needs.fetch-results.outputs.params_exist == 'true'"
     runs-on: ubuntu-latest
     strategy:
-      matrix:
-        chunk: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20]
+      matrix: ${{ fromJson(needs.generate-matrix.outputs.matrix) }}
     steps:
       - name: Download artifacts
         uses: actions/download-artifact@v4
@@ -91,8 +121,7 @@ jobs:
       - name: Generate chunk file
         run: |
           if [ -s combined-results/live-urls.txt ]; then
-            TOTAL_LINES=$(wc -l < combined-results/live-urls.txt)
-            LINES_PER_CHUNK=$(( (TOTAL_LINES + 20 - 1) / 20 ))
+            LINES_PER_CHUNK=5000
             START_LINE=$((((${{ matrix.chunk }} - 1) * LINES_PER_CHUNK) + 1))
             END_LINE=$((${{ matrix.chunk }} * LINES_PER_CHUNK))
             sed -n "${START_LINE},${END_LINE}p" combined-results/live-urls.txt > x8-chunk-${{ matrix.chunk }}.txt
@@ -133,12 +162,11 @@ jobs:
           path: x8-results-${{ matrix.chunk }}/
 
   kxss-scan:
-    needs: fetch-results
+    needs: [fetch-results, generate-matrix]
     if: "github.event.inputs.run_kxss == 'true' && needs.fetch-results.outputs.urls_exist == 'true' && needs.fetch-results.outputs.params_exist == 'true'"
     runs-on: ubuntu-latest
     strategy:
-      matrix:
-        chunk: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20]
+      matrix: ${{ fromJson(needs.generate-matrix.outputs.matrix) }}
     steps:
       - name: Download artifacts
         uses: actions/download-artifact@v4
@@ -164,8 +192,7 @@ jobs:
 
           mkdir -p kxss-results-${{ matrix.chunk }}
           if [ -s combined-results/live-urls.txt ]; then
-            TOTAL_LINES=$(wc -l < combined-results/live-urls.txt)
-            LINES_PER_CHUNK=$(( (TOTAL_LINES + 20 - 1) / 20 ))
+            LINES_PER_CHUNK=5000
             START_LINE=$((((${{ matrix.chunk }} - 1) * LINES_PER_CHUNK) + 1))
             END_LINE=$((${{ matrix.chunk }} * LINES_PER_CHUNK))
             sed -n "${START_LINE},${END_LINE}p" combined-results/live-urls.txt > kxss-urls-${{ matrix.chunk }}.txt


### PR DESCRIPTION
Replaces the fixed, hardcoded chunking logic in all scanner workflows (httpx, x8, kxss, dalfox, sqli, nuclei) with a dynamic approach.

A new 'generate-matrix' job has been added to each workflow. This job calculates the optimal number of parallel chunks based on the total number of input URLs and a pre-defined chunk size suitable for each specific scanner.

This change prevents jobs from timing out on large targets and avoids creating unnecessary empty jobs for small targets, making the entire scanning pipeline more robust, efficient, and scalable.