### PR TITLE
fix(ci): Add fail-fast: false to all scanner workflows

### DIFF
--- a/.github/workflows/dalfox-workflow-template.yaml
+++ b/.github/workflows/dalfox-workflow-template.yaml
@@ -91,6 +91,7 @@ jobs:
     if: "needs.fetch-results.outputs.urls_exist == 'true'"
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix: ${{ fromJson(needs.generate-matrix.outputs.matrix) }}
     steps:
       - name: Checkout main branch

--- a/.github/workflows/nuclei-workflow-template.yaml
+++ b/.github/workflows/nuclei-workflow-template.yaml
@@ -90,6 +90,7 @@ jobs:
     if: "needs.fetch-results.outputs.urls_exist == 'true'"
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix: ${{ fromJson(needs.generate-matrix.outputs.matrix) }}
     steps:
       - name: Download artifacts

--- a/.github/workflows/sqli-workflow-template.yaml
+++ b/.github/workflows/sqli-workflow-template.yaml
@@ -90,6 +90,7 @@ jobs:
     if: "needs.fetch-results.outputs.urls_exist == 'true'"
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix: ${{ fromJson(needs.generate-matrix.outputs.matrix) }}
     steps:
       - name: Download artifacts

--- a/.github/workflows/x8-kxss-workflow.yaml
+++ b/.github/workflows/x8-kxss-workflow.yaml
@@ -104,6 +104,7 @@ jobs:
     if: "github.event.inputs.run_x8 == 'true' && needs.fetch-results.outputs.urls_exist == 'true' && needs.fetch-results.outputs.params_exist == 'true'"
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix: ${{ fromJson(needs.generate-matrix.outputs.matrix) }}
     steps:
       - name: Download artifacts
@@ -169,6 +170,7 @@ jobs:
     if: "github.event.inputs.run_kxss == 'true' && needs.fetch-results.outputs.urls_exist == 'true' && needs.fetch-results.outputs.params_exist == 'true'"
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix: ${{ fromJson(needs.generate-matrix.outputs.matrix) }}
     steps:
       - name: Download artifacts


### PR DESCRIPTION
This commit adds 'fail-fast: false' to the strategy matrix of all downstream scanner jobs (x8, kxss, dalfox, sqli, nuclei).

This ensures that if a single parallel job (chunk) fails due to an installation issue or a specific URL error, it will not cancel all other in-progress jobs in the matrix. This makes the overall scanning process more resilient and ensures that a single point of failure does not stop the entire scan.