### PR TITLE
fix(ci): Use git clone and build to install uro

### DIFF
--- a/.github/workflows/Master-Scanning.yaml
+++ b/.github/workflows/Master-Scanning.yaml
@@ -53,7 +53,11 @@ jobs:
           go install github.com/tomnomnom/waybackurls@latest
           go install github.com/lc/gau/v2/cmd/gau@latest
           go install github.com/tomnomnom/unfurl@latest
-          go install github.com/s0md3v/uro@latest
+          git clone https://github.com/s0md3v/uro.git
+          cd uro
+          go build .
+          sudo mv uro /usr/local/bin/
+          cd ..
           echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
 
       - name: Gather URLs


### PR DESCRIPTION
This commit fixes a Go module error that occurred when trying to install the 'uro' tool using 'go install'.

The installation method has been changed to a more robust process:
1.  Clone the 'uro' repository directly from GitHub.
2.  Build the tool from source using 'go build'.
3.  Move the compiled binary into '/usr/local/bin/'.

This ensures the tool is installed reliably and resolves the workflow failure.