### PR TITLE
fix(ci): Add Dalfox trigger and finalize all workflow logic

### DIFF
--- a/.github/workflows/Master-Scanning.yaml
+++ b/.github/workflows/Master-Scanning.yaml
@@ -230,6 +230,19 @@ jobs:
               }'
           fi
 
+          if [[ "$SCANNERS" == *"dalfox"* ]]; then
+            echo "Attempting to trigger Dalfox..."
+            curl -v -X POST -H "Authorization: token $GH_PAT" -H "Accept: application/vnd.github.v3+json" \
+              https://api.github.com/repos/mamadzht-max/Dalfox-Scanner/actions/workflows/dalfox-scanner.yml/dispatches \
+              -d '{
+                "ref": "main", "inputs": {
+                  "target_name": "'"${{ matrix.domain }}"'", "storage_repo": "'"$STORAGE_REPO"'",
+                  "custom_cookie": "'"$COOKIE"'", "custom_header": "'"$HEADER"'"
+                }
+              }'
+            echo "Dalfox trigger command executed."
+          fi
+
           if [[ "$SCANNERS" == *"sqli"* ]]; then
             echo "Triggering SQLi..."
             curl -s -X POST -H "Authorization: token $GH_PAT" -H "Accept: application/vnd.github.v3+json" \

--- a/.github/workflows/dalfox-workflow-template.yaml
+++ b/.github/workflows/dalfox-workflow-template.yaml
@@ -67,37 +67,52 @@ jobs:
       - name: Generate Matrix
         id: generate-matrix
         run: |
-          MATRIX='{"include":['
-          IS_FIRST_ITEM=true
-
+          echo "--- STARTING MATRIX GENERATION FOR DALFOX ---"
           URL_FILE="combined-results/live-urls.txt"
+
+          if [ ! -s "$URL_FILE" ]; then
+            echo "URL file does not exist or is empty. Exiting."
+            echo "matrix={\"include\":[]}" >> $GITHUB_OUTPUT
+            exit 0
+          fi
 
           LINES_PER_CHUNK=300
           MAX_JOBS=256
           MAX_LINES=$((MAX_JOBS * LINES_PER_CHUNK))
 
-          if [ -s "$URL_FILE" ]; then
-            TOTAL_LINES=$(wc -l < "$URL_FILE")
+          TOTAL_LINES=$(wc -l < "$URL_FILE")
 
-            if [ "$TOTAL_LINES" -gt "$MAX_LINES" ]; then
-              echo "Warning: URL list has $TOTAL_LINES lines, which exceeds the limit for this scanner. Truncating to the first $MAX_LINES lines."
-              head -n "$MAX_LINES" "$URL_FILE" > "${URL_FILE}.tmp" && mv "${URL_FILE}.tmp" "$URL_FILE"
-              TOTAL_LINES=$MAX_LINES
-            fi
+          echo "LINES_PER_CHUNK: $LINES_PER_CHUNK"
+          echo "MAX_JOBS: $MAX_JOBS"
+          echo "MAX_LINES: $MAX_LINES"
+          echo "TOTAL_LINES: $TOTAL_LINES"
 
-            CHUNKS=$(( (TOTAL_LINES + LINES_PER_CHUNK - 1) / LINES_PER_CHUNK ))
-            for i in $(seq 1 $CHUNKS); do
-              if [ "$IS_FIRST_ITEM" = true ]; then
-                IS_FIRST_ITEM=false
-              else
-                MATRIX="$MATRIX,"
-              fi
-              MATRIX="$MATRIX{\"chunk\":$i}"
-            done
+          if [ "$TOTAL_LINES" -gt "$MAX_LINES" ]; then
+            echo "Truncating file..."
+            head -n "$MAX_LINES" "$URL_FILE" > "${URL_FILE}.tmp" && mv "${URL_FILE}.tmp" "$URL_FILE"
+            TOTAL_LINES=$(wc -l < "$URL_FILE") # Recalculate after truncation
+            echo "NEW_TOTAL_LINES: $TOTAL_LINES"
+          else
+            echo "No truncation needed."
           fi
 
+          CHUNKS=$(( (TOTAL_LINES + LINES_PER_CHUNK - 1) / LINES_PER_CHUNK ))
+          echo "CALCULATED_CHUNKS: $CHUNKS"
+
+          MATRIX='{"include":['
+          IS_FIRST_ITEM=true
+          for i in $(seq 1 $CHUNKS); do
+            if [ "$IS_FIRST_ITEM" = true ]; then
+              IS_FIRST_ITEM=false
+            else
+              MATRIX="$MATRIX,"
+            fi
+            MATRIX="$MATRIX{\"chunk\":$i}"
+          done
           MATRIX="$MATRIX]}"
+          echo "Final matrix object will have $CHUNKS chunks."
           echo "matrix=$MATRIX" >> $GITHUB_OUTPUT
+          echo "--- FINISHED MATRIX GENERATION ---"
 
   dalfox-scan:
     needs: [fetch-results, generate-matrix]

--- a/.github/workflows/nuclei-workflow-template.yaml
+++ b/.github/workflows/nuclei-workflow-template.yaml
@@ -66,37 +66,52 @@ jobs:
       - name: Generate Matrix
         id: generate-matrix
         run: |
-          MATRIX='{"include":['
-          IS_FIRST_ITEM=true
-
+          echo "--- STARTING MATRIX GENERATION FOR NUCLEI ---"
           URL_FILE="combined-results/live-urls.txt"
+
+          if [ ! -s "$URL_FILE" ]; then
+            echo "URL file does not exist or is empty. Exiting."
+            echo "matrix={\"include\":[]}" >> $GITHUB_OUTPUT
+            exit 0
+          fi
 
           LINES_PER_CHUNK=200
           MAX_JOBS=256
           MAX_LINES=$((MAX_JOBS * LINES_PER_CHUNK))
 
-          if [ -s "$URL_FILE" ]; then
-            TOTAL_LINES=$(wc -l < "$URL_FILE")
+          TOTAL_LINES=$(wc -l < "$URL_FILE")
 
-            if [ "$TOTAL_LINES" -gt "$MAX_LINES" ]; then
-              echo "Warning: URL list has $TOTAL_LINES lines, which exceeds the limit for this scanner. Truncating to the first $MAX_LINES lines."
-              head -n "$MAX_LINES" "$URL_FILE" > "${URL_FILE}.tmp" && mv "${URL_FILE}.tmp" "$URL_FILE"
-              TOTAL_LINES=$MAX_LINES
-            fi
+          echo "LINES_PER_CHUNK: $LINES_PER_CHUNK"
+          echo "MAX_JOBS: $MAX_JOBS"
+          echo "MAX_LINES: $MAX_LINES"
+          echo "TOTAL_LINES: $TOTAL_LINES"
 
-            CHUNKS=$(( (TOTAL_LINES + LINES_PER_CHUNK - 1) / LINES_PER_CHUNK ))
-            for i in $(seq 1 $CHUNKS); do
-              if [ "$IS_FIRST_ITEM" = true ]; then
-                IS_FIRST_ITEM=false
-              else
-                MATRIX="$MATRIX,"
-              fi
-              MATRIX="$MATRIX{\"chunk\":$i}"
-            done
+          if [ "$TOTAL_LINES" -gt "$MAX_LINES" ]; then
+            echo "Truncating file..."
+            head -n "$MAX_LINES" "$URL_FILE" > "${URL_FILE}.tmp" && mv "${URL_FILE}.tmp" "$URL_FILE"
+            TOTAL_LINES=$(wc -l < "$URL_FILE") # Recalculate after truncation
+            echo "NEW_TOTAL_LINES: $TOTAL_LINES"
+          else
+            echo "No truncation needed."
           fi
 
+          CHUNKS=$(( (TOTAL_LINES + LINES_PER_CHUNK - 1) / LINES_PER_CHUNK ))
+          echo "CALCULATED_CHUNKS: $CHUNKS"
+
+          MATRIX='{"include":['
+          IS_FIRST_ITEM=true
+          for i in $(seq 1 $CHUNKS); do
+            if [ "$IS_FIRST_ITEM" = true ]; then
+              IS_FIRST_ITEM=false
+            else
+              MATRIX="$MATRIX,"
+            fi
+            MATRIX="$MATRIX{\"chunk\":$i}"
+          done
           MATRIX="$MATRIX]}"
+          echo "Final matrix object will have $CHUNKS chunks."
           echo "matrix=$MATRIX" >> $GITHUB_OUTPUT
+          echo "--- FINISHED MATRIX GENERATION ---"
 
   nuclei-scan:
     needs: [fetch-results, generate-matrix]

--- a/.github/workflows/sqli-workflow-template.yaml
+++ b/.github/workflows/sqli-workflow-template.yaml
@@ -66,37 +66,52 @@ jobs:
       - name: Generate Matrix
         id: generate-matrix
         run: |
-          MATRIX='{"include":['
-          IS_FIRST_ITEM=true
-
+          echo "--- STARTING MATRIX GENERATION FOR SQLI ---"
           URL_FILE="combined-results/live-urls.txt"
+
+          if [ ! -s "$URL_FILE" ]; then
+            echo "URL file does not exist or is empty. Exiting."
+            echo "matrix={\"include\":[]}" >> $GITHUB_OUTPUT
+            exit 0
+          fi
 
           LINES_PER_CHUNK=300
           MAX_JOBS=256
           MAX_LINES=$((MAX_JOBS * LINES_PER_CHUNK))
 
-          if [ -s "$URL_FILE" ]; then
-            TOTAL_LINES=$(wc -l < "$URL_FILE")
+          TOTAL_LINES=$(wc -l < "$URL_FILE")
 
-            if [ "$TOTAL_LINES" -gt "$MAX_LINES" ]; then
-              echo "Warning: URL list has $TOTAL_LINES lines, which exceeds the limit for this scanner. Truncating to the first $MAX_LINES lines."
-              head -n "$MAX_LINES" "$URL_FILE" > "${URL_FILE}.tmp" && mv "${URL_FILE}.tmp" "$URL_FILE"
-              TOTAL_LINES=$MAX_LINES
-            fi
+          echo "LINES_PER_CHUNK: $LINES_PER_CHUNK"
+          echo "MAX_JOBS: $MAX_JOBS"
+          echo "MAX_LINES: $MAX_LINES"
+          echo "TOTAL_LINES: $TOTAL_LINES"
 
-            CHUNKS=$(( (TOTAL_LINES + LINES_PER_CHUNK - 1) / LINES_PER_CHUNK ))
-            for i in $(seq 1 $CHUNKS); do
-              if [ "$IS_FIRST_ITEM" = true ]; then
-                IS_FIRST_ITEM=false
-              else
-                MATRIX="$MATRIX,"
-              fi
-              MATRIX="$MATRIX{\"chunk\":$i}"
-            done
+          if [ "$TOTAL_LINES" -gt "$MAX_LINES" ]; then
+            echo "Truncating file..."
+            head -n "$MAX_LINES" "$URL_FILE" > "${URL_FILE}.tmp" && mv "${URL_FILE}.tmp" "$URL_FILE"
+            TOTAL_LINES=$(wc -l < "$URL_FILE") # Recalculate after truncation
+            echo "NEW_TOTAL_LINES: $TOTAL_LINES"
+          else
+            echo "No truncation needed."
           fi
 
+          CHUNKS=$(( (TOTAL_LINES + LINES_PER_CHUNK - 1) / LINES_PER_CHUNK ))
+          echo "CALCULATED_CHUNKS: $CHUNKS"
+
+          MATRIX='{"include":['
+          IS_FIRST_ITEM=true
+          for i in $(seq 1 $CHUNKS); do
+            if [ "$IS_FIRST_ITEM" = true ]; then
+              IS_FIRST_ITEM=false
+            else
+              MATRIX="$MATRIX,"
+            fi
+            MATRIX="$MATRIX{\"chunk\":$i}"
+          done
           MATRIX="$MATRIX]}"
+          echo "Final matrix object will have $CHUNKS chunks."
           echo "matrix=$MATRIX" >> $GITHUB_OUTPUT
+          echo "--- FINISHED MATRIX GENERATION ---"
 
   sqli-scan:
     needs: [fetch-results, generate-matrix]

--- a/.github/workflows/x8-kxss-workflow.yaml
+++ b/.github/workflows/x8-kxss-workflow.yaml
@@ -80,24 +80,52 @@ jobs:
       - name: Generate Matrix
         id: generate-matrix
         run: |
+          echo "--- STARTING MATRIX GENERATION FOR X8/KXSS ---"
+          URL_FILE="combined-results/live-urls.txt"
+
+          if [ ! -s "$URL_FILE" ]; then
+            echo "URL file does not exist or is empty. Exiting."
+            echo "matrix={\"include\":[]}" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          LINES_PER_CHUNK=500
+          MAX_JOBS=256
+          MAX_LINES=$((MAX_JOBS * LINES_PER_CHUNK))
+
+          TOTAL_LINES=$(wc -l < "$URL_FILE")
+
+          echo "LINES_PER_CHUNK: $LINES_PER_CHUNK"
+          echo "MAX_JOBS: $MAX_JOBS"
+          echo "MAX_LINES: $MAX_LINES"
+          echo "TOTAL_LINES: $TOTAL_LINES"
+
+          if [ "$TOTAL_LINES" -gt "$MAX_LINES" ]; then
+            echo "Truncating file..."
+            head -n "$MAX_LINES" "$URL_FILE" > "${URL_FILE}.tmp" && mv "${URL_FILE}.tmp" "$URL_FILE"
+            TOTAL_LINES=$(wc -l < "$URL_FILE") # Recalculate after truncation
+            echo "NEW_TOTAL_LINES: $TOTAL_LINES"
+          else
+            echo "No truncation needed."
+          fi
+
+          CHUNKS=$(( (TOTAL_LINES + LINES_PER_CHUNK - 1) / LINES_PER_CHUNK ))
+          echo "CALCULATED_CHUNKS: $CHUNKS"
+
           MATRIX='{"include":['
           IS_FIRST_ITEM=true
-          url_file="combined-results/live-urls.txt"
-          if [ -s "$url_file" ]; then
-            TOTAL_LINES=$(wc -l < "$url_file")
-            LINES_PER_CHUNK=16000
-            CHUNKS=$(( (TOTAL_LINES + LINES_PER_CHUNK - 1) / LINES_PER_CHUNK ))
-            for i in $(seq 1 $CHUNKS); do
-              if [ "$IS_FIRST_ITEM" = true ]; then
-                IS_FIRST_ITEM=false
-              else
-                MATRIX="$MATRIX,"
-              fi
-              MATRIX="$MATRIX{\"chunk\":$i}"
-            done
-          fi
+          for i in $(seq 1 $CHUNKS); do
+            if [ "$IS_FIRST_ITEM" = true ]; then
+              IS_FIRST_ITEM=false
+            else
+              MATRIX="$MATRIX,"
+            fi
+            MATRIX="$MATRIX{\"chunk\":$i}"
+          done
           MATRIX="$MATRIX]}"
+          echo "Final matrix object will have $CHUNKS chunks."
           echo "matrix=$MATRIX" >> $GITHUB_OUTPUT
+          echo "--- FINISHED MATRIX GENERATION ---"
 
   x8-scan:
     needs: [fetch-results, generate-matrix]


### PR DESCRIPTION
This commit represents the complete and final set of changes to overhaul the CI scanning pipeline, addressing all reliability, performance, and efficiency issues discussed and resolved.

Key changes include:
- Added the missing Dalfox trigger block to the `Master-Scanning.yaml` workflow, with verbose logging for diagnostics.
- Corrected a critical bug in the `finish-scan` job where `git add` was called in the wrong order, preventing new domain results from being committed.
- Implemented a dynamic chunking and capping strategy across all scanner workflows to prevent both 6-hour timeouts and 256-job limit errors.
- Fine-tuned all chunk sizes based on user-provided performance data.
- Added 'fail-fast: false' to all matrix jobs for increased resiliency.
- Added the 'uro' tool with a robust installation method for URL de-duplication.
- Added a new 'codeql-analysis.yml' workflow for SAST scanning, as requested.