### PR TITLE
feat: Update LINES_PER_CHUNK to 2500 in x8-kxss-workflow

### DIFF
--- a/.github/workflows/x8-kxss-workflow.yaml
+++ b/.github/workflows/x8-kxss-workflow.yaml
@@ -1,7 +1,7 @@
 name: "XSS Scanner Workflow"
 
 env:
-  LINES_PER_CHUNK: 500
+  LINES_PER_CHUNK: 2500
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
This commit updates the LINES_PER_CHUNK environment variable in the x8-kxss-workflow.yaml file from 500 to 2500 as requested.