### PR TITLE
fix: Isolate downloaded artifacts to prevent overwriting repo files

### DIFF
--- a/.github/scripts/run_httpx_with_retry.sh
+++ b/.github/scripts/run_httpx_with_retry.sh
@@ -12,6 +12,9 @@ HTTPX_COMMAND="httpx -l $INPUT_FILE -silent -threads 25 -timeout 10 -retries 2 -
 # Run httpx on the input file. If it fails, split the file and retry.
 if ! eval $HTTPX_COMMAND; then
   echo "httpx failed on $INPUT_FILE. Splitting the file and retrying."
+  # Clear the output file to prevent duplicates
+  > $OUTPUT_FILE
+
   # Split the input file into 5 smaller files
   split -n l/5 $INPUT_FILE chunk-
 

--- a/.github/workflows/Master-Scanning.yaml
+++ b/.github/workflows/Master-Scanning.yaml
@@ -124,6 +124,9 @@ jobs:
       fail-fast: false
       matrix: ${{ fromJson(needs.generate-httpx-matrix.outputs.matrix) }}
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
       - name: Install httpx
         run: |
           go install -v github.com/projectdiscovery/httpx/cmd/httpx@latest
@@ -133,12 +136,12 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: discovery-artifacts-${{ matrix.domain }}
-          path: .
+          path: domain_artifacts
 
       - name: Get URL chunk
         run: |
           CHUNK_NUMBER=${{ matrix.chunk }}
-          INPUT_FILE="non-static-urls.txt"
+          INPUT_FILE="domain_artifacts/non-static-urls.txt"
           CHUNK_FILE="httpx-chunk.txt"
           LINES_PER_CHUNK=4000
           START_LINE=$(( (CHUNK_NUMBER - 1) * LINES_PER_CHUNK + 1 ))


### PR DESCRIPTION
The `run-httpx-scan` job was still failing with a "No such file or directory" error for the retry script, even after adding a checkout step.

This was caused by the `download-artifact` step, which was downloading the domain URL list into the root directory (`.`). This action overwrote the checked-out repository files, deleting the `.github` directory and the retry script within it.

This commit fixes the issue by:
- Changing the artifact download path from `.` to a dedicated `domain_artifacts/` directory.
- Updating the subsequent `Get URL chunk` step to read the URL list from this new, isolated directory.

This prevents the downloaded artifact from interfering with the repository files, ensuring the retry script is always available and resolving the persistent error.