### PR TITLE
The `run-httpx-scan` job was failing during the "Clean up disk space"…

### DIFF
--- a/.github/workflows/Master-Scanning.yaml
+++ b/.github/workflows/Master-Scanning.yaml
@@ -160,7 +160,7 @@ jobs:
 
       - name: Clean up disk space
         if: always()
-        run: rm non-static-urls.txt
+        run: rm -rf domain_artifacts
 
   # Job 5: For each domain, consolidate httpx results and trigger downstream scanners
   finish-scan:


### PR DESCRIPTION
… step because it attempted to remove `non-static-urls.txt` from the root directory.

However, the file is located inside the `domain_artifacts` directory, which is created in a previous step to store downloaded artifacts.

This commit corrects the cleanup command to `rm -rf domain_artifacts`, ensuring that the temporary directory and its contents are properly removed, which resolves the workflow error.